### PR TITLE
SlackState 관련 컴파일 에러 수정

### DIFF
--- a/app/src/main/java/com/waffle22/wafflytime/ui/AuthCheckViewModel.kt
+++ b/app/src/main/java/com/waffle22/wafflytime/ui/AuthCheckViewModel.kt
@@ -17,11 +17,11 @@ class AuthCheckViewModel(
     private val authStorage: AuthStorage,
     private val moshi: Moshi
 ): ViewModel() {
-    private val _authState = MutableStateFlow<SlackState<Any?>>(SlackState("0",null,null))
+    private val _authState = MutableStateFlow<SlackState<Any?>>(SlackState("0",null,null, null))
     val authState: StateFlow<SlackState<Any?>> = _authState
 
     fun resetAuthState(){
-        _authState.value = SlackState("0",null,null)
+        _authState.value = SlackState("0",null,null, null)
     }
 
     fun checkAuth(){
@@ -30,15 +30,15 @@ class AuthCheckViewModel(
                 val responseUserInfo = wafflyApiService.getUserInfo()
                 if (responseUserInfo.isSuccessful){
                     authStorage.setUserDtoInfo(responseUserInfo.body()!!)
-                    _authState.value = SlackState("200",null,null)
+                    _authState.value = SlackState("200",null,null, null)
                 } else {
                     authStorage.clearAuthInfo()
                     val errorResponse = HttpException(responseUserInfo).parseError(moshi)!!
-                    _authState.value = SlackState(errorResponse.statusCode,errorResponse.errorCode,errorResponse.message)
+                    _authState.value = SlackState(errorResponse.statusCode,errorResponse.errorCode,errorResponse.message, null)
                 }
             } catch (e:java.lang.Exception) {
                 authStorage.clearAuthInfo()
-                _authState.value = SlackState("-1",null,"System Corruption")
+                _authState.value = SlackState("-1",null,"System Corruption", null)
             }
         }
     }

--- a/app/src/main/java/com/waffle22/wafflytime/ui/preferences/ChangePasswordViewModel.kt
+++ b/app/src/main/java/com/waffle22/wafflytime/ui/preferences/ChangePasswordViewModel.kt
@@ -22,7 +22,7 @@ class ChangePasswordViewModel(
 ): ViewModel() {
 
     private val _state = MutableStateFlow(SlackState<Any>("0", null, null, null))
-    val state: StateFlow<SlackState<Nothing>> = _state
+    val state: StateFlow<SlackState<Any>> = _state
 
     fun changePassword(newPassword: String, oldPassword: String, confirmPassword: String) {
         _state.value = SlackState<Any>("0", null, null, null)

--- a/app/src/main/java/com/waffle22/wafflytime/ui/preferences/LogoutViewModel.kt
+++ b/app/src/main/java/com/waffle22/wafflytime/ui/preferences/LogoutViewModel.kt
@@ -18,23 +18,23 @@ class LogoutViewModel(
     private val moshi: Moshi
 ) : ViewModel() {
 
-    private val _logoutState = MutableStateFlow(SlackState<Any>("0",null,null,null))
+    private val _logoutState = MutableStateFlow(SlackState("0",null,null,null))
     val logoutState: StateFlow<SlackState<Nothing>> = _logoutState
 
     fun logout() {
-        _logoutState.value = SlackState<Any>("0", null, null, null)
+        _logoutState.value = SlackState("0", null, null, null)
         viewModelScope.launch{
             try {
                 val response = wafflyApiService.logout()
                 if (response.isSuccessful) {
                     authStorage.clearAuthInfo()
-                    _logoutState.value = SlackState<Any>("200",null,null,null)
+                    _logoutState.value = SlackState("200",null,null,null)
                 } else {
                     val errorResponse = HttpException(response).parseError(moshi)!!
-                    _logoutState.value = SlackState<Any>(errorResponse.statusCode,errorResponse.errorCode,errorResponse.message,null)
+                    _logoutState.value = SlackState(errorResponse.statusCode,errorResponse.errorCode,errorResponse.message,null)
                 }
             } catch (e:java.lang.Exception) {
-                _logoutState.value = SlackState<Any>("-1",null,"System Corruption",null)
+                _logoutState.value = SlackState("-1",null,"System Corruption",null)
             }
         }
     }

--- a/app/src/main/java/com/waffle22/wafflytime/ui/preferences/MypageEmailViewModel.kt
+++ b/app/src/main/java/com/waffle22/wafflytime/ui/preferences/MypageEmailViewModel.kt
@@ -21,9 +21,9 @@ class MypageEmailViewModel(
     private val moshi: Moshi
 ): ViewModel() {
 
-    private val _emailState = MutableStateFlow(SlackState<Any>("0", null, null, null))
+    private val _emailState = MutableStateFlow(SlackState("0", null, null, null))
     val emailState: StateFlow<SlackState<Nothing>> = _emailState
-    private val _codeState = MutableStateFlow(SlackState<Any>("0", null, null, null))
+    private val _codeState = MutableStateFlow(SlackState("0", null, null, null))
     val codeState: StateFlow<SlackState<Nothing>> = _codeState
     private lateinit var email: String
     private lateinit var code: String
@@ -33,26 +33,26 @@ class MypageEmailViewModel(
     }
 
     fun submitEmail(emailInput: String) {
-        _emailState.value = SlackState<Any>("0", null, null, null)
+        _emailState.value = SlackState("0", null, null, null)
         viewModelScope.launch {
             try {
                 email = emailInput
                 val response: Response<EmailCode> = wafflyApiService.emailAuth(EmailRequest(email))
                 if (response.isSuccessful){
                     code = response.body()!!.emailCode
-                    _emailState.value = SlackState<Any>(response.code().toString(),null,null,null)
+                    _emailState.value = SlackState(response.code().toString(),null,null,null)
                 } else {
                     val errorResponse = HttpException(response).parseError(moshi)!!
-                    _emailState.value = SlackState<Any>(errorResponse.statusCode, errorResponse.errorCode, errorResponse.message, null)
+                    _emailState.value = SlackState(errorResponse.statusCode, errorResponse.errorCode, errorResponse.message, null)
                 }
             } catch (e:java.lang.Exception) {
-                _emailState.value = SlackState<Any>("-1",null,"System Corruption", null)
+                _emailState.value = SlackState("-1",null,"System Corruption", null)
             }
         }
     }
 
     fun checkCode(codeInput: String) {
-        _codeState.value = SlackState<Any>("0", null, null, null)
+        _codeState.value = SlackState("0", null, null, null)
         viewModelScope.launch {
             try {
                 if (codeInput == code) {
@@ -60,16 +60,16 @@ class MypageEmailViewModel(
                     if (response.isSuccessful){
                         authStorage.modifyUserDtoInfo(AuthStorage.UserUnivEmailKey, email)
 //                        authStorage.setTokenInfo(response.body()!!.accessToken, response.body()!!.refreshToken)
-                        _codeState.value = SlackState<Any>(response.code().toString(),null,null, null)
+                        _codeState.value = SlackState(response.code().toString(),null,null, null)
                     } else {
                         val errorResponse = HttpException(response).parseError(moshi)!!
-                        _codeState.value = SlackState<Any>(errorResponse.statusCode, errorResponse.errorCode, errorResponse.message, null)
+                        _codeState.value = SlackState(errorResponse.statusCode, errorResponse.errorCode, errorResponse.message, null)
                     }
                 } else {
-                    _codeState.value = SlackState<Any>("-2",null,"코드가 일치하지 않습니다.", null)
+                    _codeState.value = SlackState("-2",null,"코드가 일치하지 않습니다.", null)
                 }
             } catch (e:java.lang.Exception) {
-                _codeState.value = SlackState<Any>("-1",null,"System Corruption", null)
+                _codeState.value = SlackState("-1",null,"System Corruption", null)
             }
         }
     }

--- a/app/src/main/java/com/waffle22/wafflytime/ui/preferences/SetNicknameViewModel.kt
+++ b/app/src/main/java/com/waffle22/wafflytime/ui/preferences/SetNicknameViewModel.kt
@@ -23,7 +23,7 @@ class SetNicknameViewModel(
     private val moshi: Moshi
 ): ViewModel() {
 
-    private val _state = MutableStateFlow(SlackState<Any>("0", null, null, null))
+    private val _state = MutableStateFlow(SlackState("0", null, null, null))
     val state: StateFlow<SlackState<Nothing>> = _state
 
     suspend fun checkUsername(newUsername: String): Boolean {
@@ -32,13 +32,13 @@ class SetNicknameViewModel(
             false
         } else {
             val errorResponse = HttpException(response).parseError(moshi)!!
-            _state.value = SlackState<Any>(errorResponse.statusCode, errorResponse.statusCode, errorResponse.message, null)
+            _state.value = SlackState(errorResponse.statusCode, errorResponse.statusCode, errorResponse.message, null)
             true
         }
     }
 
     fun changeUsername(newUsername: String) {
-        _state.value = SlackState<Any>("0", null, null, null)
+        _state.value = SlackState("0", null, null, null)
         viewModelScope.launch {
             try {
                 val duplicate = checkUsername(newUsername)
@@ -48,10 +48,10 @@ class SetNicknameViewModel(
                     )
                     if (response.isSuccessful) {
                         authStorage.modifyUserDtoInfo(AuthStorage.UserNickNameKey, newUsername)
-                        _state.value = SlackState<Any>(response.code().toString(), null, null, null)
+                        _state.value = SlackState(response.code().toString(), null, null, null)
                     } else {
                         val errorResponse = HttpException(response).parseError(moshi)!!
-                        _state.value = SlackState<Any>(
+                        _state.value = SlackState(
                             errorResponse.statusCode,
                             errorResponse.statusCode,
                             errorResponse.message,
@@ -62,7 +62,7 @@ class SetNicknameViewModel(
             }
             catch (e: Exception) {
                 Log.e("EXCEPTION", e.message.toString())
-                _state.value = SlackState<Any>("-1", null, "System Corruption", null)
+                _state.value = SlackState("-1", null, "System Corruption", null)
             }
         }
     }

--- a/app/src/main/java/com/waffle22/wafflytime/ui/preferences/SetProfilePicViewModel.kt
+++ b/app/src/main/java/com/waffle22/wafflytime/ui/preferences/SetProfilePicViewModel.kt
@@ -23,14 +23,14 @@ class SetProfilePicViewModel(
     private val moshi: Moshi
 ): ViewModel() {
 
-    private val _state = MutableStateFlow(SlackState<Any>("0", null, null, null))
+    private val _state = MutableStateFlow(SlackState("0", null, null, null))
     val state: StateFlow<SlackState<Nothing>> = _state
 
     private val _profileUrl = MutableStateFlow<SlackState<String>>(SlackState("0", null, null, null))
     val profileUrl: StateFlow<SlackState<String>> = _profileUrl
 
     fun setProfilePic(fileName: String, byteArray: ByteArray) {
-        _state.value = SlackState<Any>("0", null, null, null)
+        _state.value = SlackState("0", null, null, null)
         viewModelScope.launch {
             try {
                 val response: Response<UserDTO> = wafflyApiService.setProfilePic(
@@ -39,32 +39,32 @@ class SetProfilePicViewModel(
                 if(response.isSuccessful) {
                     val response2: Response<Unit> = wafflyApiService.uploadProfilePic(response.body()!!.profileUrl!!, byteArray.toRequestBody("application/octet-stream".toMediaTypeOrNull()))
                     if(response2.isSuccessful) {
-                        _state.value = SlackState<Any>(response.code().toString(), null, null, null)
+                        _state.value = SlackState(response.code().toString(), null, null, null)
                     }
                     else {
-                        _state.value = SlackState<Any>(response.code().toString(), null, "Cannot upload picture", null)
+                        _state.value = SlackState(response.code().toString(), null, "Cannot upload picture", null)
                     }
                 } else {
                     val errorResponse = HttpException(response).parseError(moshi)!!
-                    _state.value = SlackState<Any>(errorResponse.statusCode, errorResponse.statusCode, errorResponse.message, null)
+                    _state.value = SlackState(errorResponse.statusCode, errorResponse.statusCode, errorResponse.message, null)
                 }
             }
             catch (e: Exception) {
-                _state.value = SlackState<Any>("-1", null, "System Corruption", null)
+                _state.value = SlackState("-1", null, "System Corruption", null)
             }
         }
     }
 
     fun deleteProfilePic() {
-        _state.value = SlackState<Any>("0", null, null, null)
+        _state.value = SlackState("0", null, null, null)
         viewModelScope.launch {
             try {
                 val response: Response<UserDTO> = wafflyApiService.deleteProfilePic()
                 if (response.isSuccessful) {
-                    _state.value = SlackState<Any>(response.code().toString(), null, null, null)
+                    _state.value = SlackState(response.code().toString(), null, null, null)
                 } else {
                     val errorResponse = HttpException(response).parseError(moshi)!!
-                    _state.value = SlackState<Any>(
+                    _state.value = SlackState(
                         errorResponse.statusCode,
                         errorResponse.statusCode,
                         errorResponse.message,
@@ -73,7 +73,7 @@ class SetProfilePicViewModel(
                 }
             }
             catch (e: Exception) {
-                _state.value = SlackState<Any>("-1", null, "System Corruption", null)
+                _state.value = SlackState("-1", null, "System Corruption", null)
             }
         }
     }


### PR DESCRIPTION
컴파일 에러 수정해서 올렸습니다!
SlackState의 생성자에서 dataHolder에 null을 넣어주면 SlackState<Nothing>으로 추론됩니다. 그래서 SlackState<Any>로 되어있던 SlackState 객체를 모두 SlackState<Nothing>으로 바꾸었습니다